### PR TITLE
Fix #13, Fix #14 Trigger sync on file events

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ The app uses the auth file in the `<user.home>/.storj` folder created by the lib
 
 Currently the app supports basic two-way sync between the Storj cloud to the local file system. The app will sync the content of the bucket with name `Goobox` to the local folder with name `Goobox`, which is a subfolder of the user home folder. If either the bucket or the local folder do not exist, the app will automatically create empty ones.
 
-The app will poll the Storj cloud and the local `Goobox` sync folder once per minute for any changes in the content. Basic scenarios should work: initial sync, downloading and uploading modified files. More care is required for more complex scenarios: conflicts, download/upload failures, etc.
+The app polls the Storj cloud and the local `Goobox` sync folder once per minute for any changes in the content. If file is created, deleted or modified in the local sync folder, the sync will be triggered within 5 seconds.
+
+Basic sync scenarios should work: initial sync, downloading and uploading modified files. More care is required for more complex scenarios: conflicts, download/upload failures, etc.
 
 The app uses an embedded Nitrine database for storing the current sync state of the files. The DB file can be found at the following location:
 - `C:\Users\<user-name>\AppData\Local\Goobox` for Windows

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sync app for Storj.
 
 ## Prerequisites
 
-1. Install [Java](https://java.com/download/) 7 or later. Make sure to install the 64-bit variant.
+1. Install [Java](https://java.com/download/) 8 or later. Make sure to install the 64-bit variant.
 1. Install [libstorj](https://github.com/Storj/libstorj)
 1. Import your keys using the libstorj CLI. Don't use a passcode. This is not supported yet by the sync app.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.goobox</groupId>
   <artifactId>goobox-sync-storj</artifactId>
-  <version>0.0.5</version>
+  <version>0.0.6</version>
   <packaging>jar</packaging>
 
   <name>Goobox sync app for Storj</name>
@@ -21,8 +21,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
         <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.8</source>
+            <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -78,6 +78,11 @@
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna-platform</artifactId>
       <version>4.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>io.methvin</groupId>
+      <artifactId>directory-watcher</artifactId>
+      <version>0.3.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/io/goobox/sync/storj/CheckStateTask.java
+++ b/src/main/java/io/goobox/sync/storj/CheckStateTask.java
@@ -38,13 +38,19 @@ public class CheckStateTask implements Runnable {
     private Bucket gooboxBucket;
     private BlockingQueue<Runnable> tasks;
 
-    public CheckStateTask(Bucket gooboxBucket, BlockingQueue<Runnable> tasks) {
-        this.gooboxBucket = gooboxBucket;
-        this.tasks = tasks;
+    public CheckStateTask() {
+        this.gooboxBucket = App.getInstance().getGooboxBucket();
+        this.tasks = App.getInstance().getTaskQueue();
     }
 
     @Override
     public void run() {
+        // check if there are local file operations in progress
+        if (App.getInstance().getFileWatcher().isInProgress()) {
+            System.out.println("Skip checking for changes - local file operations in progress...");
+            return;
+        }
+
         System.out.println("Checking for changes...");
         Storj.getInstance().listFiles(gooboxBucket, new ListFilesCallback() {
             @Override

--- a/src/main/java/io/goobox/sync/storj/CheckStateTask.java
+++ b/src/main/java/io/goobox/sync/storj/CheckStateTask.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
 
 import io.goobox.sync.storj.db.DB;
 import io.goobox.sync.storj.db.SyncFile;
@@ -36,7 +35,7 @@ import io.storj.libstorj.Storj;
 public class CheckStateTask implements Runnable {
 
     private Bucket gooboxBucket;
-    private BlockingQueue<Runnable> tasks;
+    private TaskQueue tasks;
 
     public CheckStateTask() {
         this.gooboxBucket = App.getInstance().getGooboxBucket();

--- a/src/main/java/io/goobox/sync/storj/TaskExecutor.java
+++ b/src/main/java/io/goobox/sync/storj/TaskExecutor.java
@@ -16,14 +16,12 @@
  */
 package io.goobox.sync.storj;
 
-import java.util.concurrent.BlockingQueue;
-
 public class TaskExecutor extends Thread {
 
-    private BlockingQueue<Runnable> tasks;
+    private TaskQueue tasks;
     private volatile Runnable currentTask;
 
-    public TaskExecutor(BlockingQueue<Runnable> tasks) {
+    public TaskExecutor(TaskQueue tasks) {
         this.tasks = tasks;
     }
 

--- a/src/main/java/io/goobox/sync/storj/db/SyncFile.java
+++ b/src/main/java/io/goobox/sync/storj/db/SyncFile.java
@@ -27,6 +27,7 @@ import org.dizitart.no2.objects.Id;
 import io.goobox.sync.storj.Utils;
 import io.storj.libstorj.File;
 
+@SuppressWarnings("serial")
 public class SyncFile implements Serializable {
 
     @Id

--- a/src/test/java/io/goobox/sync/storj/CheckStateTaskTest.java
+++ b/src/test/java/io/goobox/sync/storj/CheckStateTaskTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Files;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.After;
 import org.junit.Before;
@@ -31,8 +30,10 @@ import org.junit.runner.RunWith;
 import io.goobox.sync.storj.db.DB;
 import io.goobox.sync.storj.db.SyncState;
 import io.goobox.sync.storj.helpers.AssertSyncFile;
+import io.goobox.sync.storj.mocks.AppMock;
 import io.goobox.sync.storj.mocks.DBMock;
 import io.goobox.sync.storj.mocks.FileMock;
+import io.goobox.sync.storj.mocks.FileWatcherMock;
 import io.goobox.sync.storj.mocks.FilesMock;
 import io.goobox.sync.storj.mocks.StorjMock;
 import io.storj.libstorj.DeleteFileCallback;
@@ -42,8 +43,6 @@ import mockit.integration.junit4.JMockit;
 @RunWith(JMockit.class)
 public class CheckStateTaskTest {
 
-    private LinkedBlockingQueue<Runnable> tasks;
-
     @BeforeClass
     public static void applySharedFakes() {
         new DBMock();
@@ -51,7 +50,7 @@ public class CheckStateTaskTest {
 
     @Before
     public void setup() {
-        tasks = new LinkedBlockingQueue<>();
+        new AppMock();
     }
 
     @After
@@ -64,8 +63,9 @@ public class CheckStateTaskTest {
         new StorjMock();
         new FilesMock();
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -80,8 +80,9 @@ public class CheckStateTaskTest {
 
         DB.setSynced(StorjMock.FILE_1, FileMock.FILE_1.getPath());
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -96,8 +97,9 @@ public class CheckStateTaskTest {
         new StorjMock(StorjMock.FILE_1);
         new FilesMock();
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(DownloadFileTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -112,8 +114,9 @@ public class CheckStateTaskTest {
         new StorjMock();
         new FilesMock(FileMock.FILE_1);
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(UploadFileTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -128,8 +131,9 @@ public class CheckStateTaskTest {
         new StorjMock(StorjMock.ENCRYPTED_FILE);
         new FilesMock();
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -142,8 +146,9 @@ public class CheckStateTaskTest {
         new StorjMock(StorjMock.ENCRYPTED_FILE);
         new FilesMock(FileMock.ENCRYPTED_FILE);
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -159,8 +164,9 @@ public class CheckStateTaskTest {
         DB.setSynced(StorjMock.FILE_1, FileMock.FILE_1.getPath());
         Files.deleteIfExists(FileMock.FILE_1.getPath());
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(DeleteCloudFileTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -188,8 +194,9 @@ public class CheckStateTaskTest {
             }
         });
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(DeleteLocalFileTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -207,8 +214,9 @@ public class CheckStateTaskTest {
         DB.setSynced(StorjMock.FILE_1, FileMock.FILE_1.getPath());
         storjMock.modifyFile1();
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(DownloadFileTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -226,8 +234,9 @@ public class CheckStateTaskTest {
         DB.setSynced(StorjMock.FILE_1, FileMock.FILE_1.getPath());
         filesMock.modifyFile1();
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(UploadFileTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -246,7 +255,8 @@ public class CheckStateTaskTest {
         storjMock.modifyFile1();
         filesMock.modifyFile1();
 
-        new CheckStateTask(null, tasks).run();
+        TaskQueue tasks = App.getInstance().getTaskQueue();
+        new CheckStateTask().run();
 
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
@@ -262,8 +272,9 @@ public class CheckStateTaskTest {
         new StorjMock(StorjMock.FILE_1);
         new FilesMock(FileMock.FILE_1);
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -278,8 +289,9 @@ public class CheckStateTaskTest {
         new StorjMock(StorjMock.MODIFIED_FILE_1);
         new FilesMock(FileMock.FILE_1);
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -297,8 +309,9 @@ public class CheckStateTaskTest {
         DB.setConflict(StorjMock.FILE_1, FileMock.FILE_1.getPath());
         storjMock.modifyFile1();
 
-        new CheckStateTask(null, tasks).run();
+        new CheckStateTask().run();
 
+        TaskQueue tasks = App.getInstance().getTaskQueue();
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
         assertTrue(tasks.isEmpty());
@@ -316,7 +329,8 @@ public class CheckStateTaskTest {
         DB.setConflict(StorjMock.FILE_1, FileMock.FILE_1.getPath());
         filesMock.modifyFile1();
 
-        new CheckStateTask(null, tasks).run();
+        TaskQueue tasks = App.getInstance().getTaskQueue();
+        new CheckStateTask().run();
 
         assertEquals(SleepTask.class, tasks.poll().getClass());
         assertEquals(CheckStateTask.class, tasks.poll().getClass());
@@ -325,6 +339,20 @@ public class CheckStateTaskTest {
         assertEquals(1, DB.size());
         assertTrue(DB.contains(StorjMock.FILE_1));
         AssertSyncFile.assertWith(StorjMock.FILE_1, FileMock.MODIFIED_FILE_1, SyncState.CONFLICT);
+    }
+
+    @Test
+    public void fileOpsInProgressTest() throws Exception {
+        new StorjMock(StorjMock.FILE_1);
+        new FilesMock(FileMock.FILE_2);
+        new FileWatcherMock(true);
+
+        new CheckStateTask().run();
+
+        TaskQueue tasks = App.getInstance().getTaskQueue();
+        assertTrue(tasks.isEmpty());
+
+        assertEquals(0, DB.size());
     }
 
 }

--- a/src/test/java/io/goobox/sync/storj/mocks/AppMock.java
+++ b/src/test/java/io/goobox/sync/storj/mocks/AppMock.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2017 Kaloyan Raev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.goobox.sync.storj.mocks;
+
+import io.goobox.sync.storj.App;
+import io.goobox.sync.storj.FileWatcher;
+import io.goobox.sync.storj.TaskQueue;
+import io.storj.libstorj.Bucket;
+import mockit.Mock;
+import mockit.MockUp;
+
+public class AppMock extends MockUp<App> {
+
+    private App instance = new App();
+    private TaskQueue tasks = new TaskQueue();
+    private FileWatcher fileWatcher = new FileWatcher();
+
+    @Mock
+    public App getInstance() {
+        return instance;
+    }
+
+    @Mock
+    public Bucket getGooboxBucket() {
+        return null;
+    }
+
+    @Mock
+    public TaskQueue getTaskQueue() {
+        return tasks;
+    }
+
+    @Mock
+    public FileWatcher getFileWatcher() {
+        return fileWatcher;
+    }
+
+}

--- a/src/test/java/io/goobox/sync/storj/mocks/FileWatcherMock.java
+++ b/src/test/java/io/goobox/sync/storj/mocks/FileWatcherMock.java
@@ -14,23 +14,23 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.goobox.sync.storj;
+package io.goobox.sync.storj.mocks;
 
-public class SleepTask implements Runnable {
+import io.goobox.sync.storj.FileWatcher;
+import mockit.Mock;
+import mockit.MockUp;
 
-    @Override
-    public synchronized void run() {
-        System.out.println("Sleeping for 1 minute...");
-        try {
-            wait(60000);
-        } catch (InterruptedException e) {
-            // nothing to do
-        }
+public class FileWatcherMock extends MockUp<FileWatcher> {
+
+    private boolean inProgress;
+
+    public FileWatcherMock(boolean inProgress) {
+        this.inProgress = inProgress;
     }
 
-    public synchronized void interrupt() {
-        System.out.println("Sleep interrupted");
-        notify();
+    @Mock
+    public boolean isInProgress() {
+        return inProgress;
     }
 
 }


### PR DESCRIPTION
A file watcher is listening for file events in the local Goobox folder. The sync task is triggered after 3-5 seconds after the last file event. This delay is necessary to ensure that there is no file copy in progress. 

A regular sync task will not execute if there is local file copy in progress to avoid uploading partially copied files.