### PR TITLE
Write log entries to stderr

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -20,7 +20,15 @@
     </encoder>
   </appender>
 
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="DEBUG">
     <appender-ref ref="FILE" />
+    <appender-ref ref="STDERR"/>
   </root>
 </configuration>


### PR DESCRIPTION
Since the GUI app's log entries contain entries which child processes write to stderr,
with this update, we can integrate several log files to one.