### PR TITLE
Cancel upload if file is not exists

### DIFF
--- a/src/main/java/io/goobox/sync/storj/UploadFileTask.java
+++ b/src/main/java/io/goobox/sync/storj/UploadFileTask.java
@@ -73,7 +73,7 @@ public class UploadFileTask implements Runnable {
                     // user might have delete large file during uploading. so we check this situation to ensure canceling is possible
                     if (!Files.exists(path)) {
                         logger.info("File {} does not exist anymore (renamed, deleted or moved). Canceling upload.", path);
-                        cancelUpload(uploadState);
+                        App.getInstance().getStorj().cancelUpload(uploadState);
                     }
                 }
 
@@ -183,10 +183,6 @@ public class UploadFileTask implements Runnable {
                 Thread.sleep(3000);
             }
         }
-    }
-
-    public boolean cancelUpload(Long id) {
-        return App.getInstance().getStorj().cancelUpload(id);
     }
 
 }

--- a/src/main/java/io/goobox/sync/storj/UploadFileTask.java
+++ b/src/main/java/io/goobox/sync/storj/UploadFileTask.java
@@ -17,6 +17,7 @@
 package io.goobox.sync.storj;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 
@@ -38,7 +39,7 @@ public class UploadFileTask implements Runnable {
     private Bucket bucket;
     private Path path;
     private String fileName;
-    private Long uploadPointer;
+    private long uploadState;
 
     public UploadFileTask(Bucket bucket, Path path) {
         this.bucket = bucket;
@@ -62,18 +63,17 @@ public class UploadFileTask implements Runnable {
         while (repeat[0]) {
             final CountDownLatch latch = new CountDownLatch(1);
 
-            uploadPointer = App.getInstance().getStorj().uploadFile(bucket, fileName, path.toString(), new UploadFileCallback() {
+            uploadState = App.getInstance().getStorj().uploadFile(bucket, fileName, path.toString(), new UploadFileCallback() {
                 @Override
                 public void onProgress(String filePath, double progress, long uploadedBytes, long totalBytes) {
                     String progressMessage = String.format("  %3d%% %15d/%d bytes",
                             (int) (progress * 100), uploadedBytes, totalBytes);
                     logger.info(progressMessage);
 
-                    // user might have delete large file during uploading. so we check this situation to ensure cancelling is possible
-                    java.io.File file = path.toFile();
-                    if (!file.exists()) {
-                        logger.debug("file is not exists (rename, delete or moved), cancelling upload");
-                        cancelUpload(uploadPointer);
+                    // user might have delete large file during uploading. so we check this situation to ensure canceling is possible
+                    if (!Files.exists(path)) {
+                        logger.info("File {} does not exist anymore (renamed, deleted or moved). Canceling upload.", path);
+                        cancelUpload(uploadState);
                     }
                 }
 
@@ -186,7 +186,6 @@ public class UploadFileTask implements Runnable {
     }
 
     public boolean cancelUpload(Long id) {
-        logger.info("canceling upload");
         return App.getInstance().getStorj().cancelUpload(id);
     }
 

--- a/src/main/java/io/goobox/sync/storj/UploadFileTask.java
+++ b/src/main/java/io/goobox/sync/storj/UploadFileTask.java
@@ -72,7 +72,7 @@ public class UploadFileTask implements Runnable {
                     // user might have delete large file during uploading. so we check this situation to ensure cancelling is possible
                     java.io.File file = path.toFile();
                     if (!file.exists()) {
-                        logger.debug("file is deleted, cancelling upload");
+                        logger.debug("file is not exists (rename, delete or moved), cancelling upload");
                         cancelUpload(uploadPointer);
                     }
                 }


### PR DESCRIPTION
This is for issue #63 and with this change, when user delete the file during uploading, if the file is not exists, upload will get cancel. In the mentioned issues, there are basically three points:
* If a user deletes a file while its being uploaded, cancel the upload.
* If its renamed when uploading, cancel the upload
* if a user moves the file while uploading, cancel the upload. Then upload it again once the user is done with the task..

Tested these scenarios work on my linux platform, although the reported issue is with windows or mac. On the file is open during user delete/rename on the file, also cannot reproduce in linux platform. Can anymore test this branch on windows/mac?