### PR TITLE
create a temporary directory and temporary file to solve the windows file in use message

### DIFF
--- a/src/main/java/io/goobox/sync/storj/UploadFileTask.java
+++ b/src/main/java/io/goobox/sync/storj/UploadFileTask.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
 import java.util.concurrent.CountDownLatch;
 
 import org.slf4j.Logger;
@@ -61,20 +63,17 @@ public class UploadFileTask implements Runnable {
         logger.info("Uploading file {}", fileName);
 
         final boolean repeat[] = { true };
-        Path tmpDir = null;
         Path tmpPath = null;
 
         try {
-            tmpDir = Files.createTempDirectory(Utils.getSyncDir(), ".~");
-            tmpPath = Files.createTempFile(tmpDir, "file", ".tmp");
+            tmpPath = Files.createTempFile("file", ".tmp", new FileAttribute<?>[0]);
             Files.copy(path, tmpPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
-            logger.info("file {} removed during temporary file creation?", path);
-            logger.info("", e);
+            logger.info("file {} removed during temporary file creation?", path, e);
             try {
                 Files.delete(tmpPath);
-                Files.delete(tmpDir);
             } catch (IOException e1) {}
+            return;
         }
 
         while (repeat[0]) {
@@ -141,7 +140,6 @@ public class UploadFileTask implements Runnable {
             } finally {
                 try {
                     Files.delete(tmpPath);
-                    Files.delete(tmpDir);
                 } catch (IOException e) { }
             }
         }

--- a/src/main/java/io/goobox/sync/storj/UploadFileTask.java
+++ b/src/main/java/io/goobox/sync/storj/UploadFileTask.java
@@ -20,14 +20,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileAttribute;
 import java.util.concurrent.CountDownLatch;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.goobox.sync.common.Utils;
 import io.goobox.sync.storj.db.DB;
 import io.storj.libstorj.Bucket;
 import io.storj.libstorj.DeleteFileCallback;

--- a/src/main/java/io/goobox/sync/storj/UploadFileTask.java
+++ b/src/main/java/io/goobox/sync/storj/UploadFileTask.java
@@ -68,8 +68,13 @@ public class UploadFileTask implements Runnable {
             tmpDir = Files.createTempDirectory(Utils.getSyncDir(), ".~");
             tmpPath = Files.createTempFile(tmpDir, "file", ".tmp");
             Files.copy(path, tmpPath, StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e1) {
+        } catch (IOException e) {
             logger.info("file {} removed during temporary file creation?", path);
+            logger.info("", e);
+            try {
+                Files.delete(tmpPath);
+                Files.delete(tmpDir);
+            } catch (IOException e1) {}
         }
 
         while (repeat[0]) {
@@ -135,8 +140,8 @@ public class UploadFileTask implements Runnable {
                 return;
             } finally {
                 try {
-                    Files.deleteIfExists(tmpPath);
-                    Files.deleteIfExists(tmpDir);
+                    Files.delete(tmpPath);
+                    Files.delete(tmpDir);
                 } catch (IOException e) { }
             }
         }

--- a/src/main/java/io/goobox/sync/storj/UploadFileTask.java
+++ b/src/main/java/io/goobox/sync/storj/UploadFileTask.java
@@ -64,7 +64,7 @@ public class UploadFileTask implements Runnable {
         Path tmpPath = null;
 
         try {
-            tmpPath = Files.createTempFile("file", ".tmp", new FileAttribute<?>[0]);
+            tmpPath = Files.createTempFile("file", ".tmp");
             Files.copy(path, tmpPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             logger.info("file {} removed during temporary file creation?", path, e);

--- a/src/test/java/io/goobox/sync/storj/UploadFileTaskTest.java
+++ b/src/test/java/io/goobox/sync/storj/UploadFileTaskTest.java
@@ -59,7 +59,7 @@ public class UploadFileTaskTest {
 
         new UploadFileTask(StorjMock.BUCKET, FileMock.FILE_1.getPath()).run();
 
-        //AssertState.assertDB(StorjMock.FILE_1, FileMock.FILE_1, SyncState.SYNCED);
+        AssertState.assertDB(StorjMock.FILE_1, FileMock.FILE_1, SyncState.SYNCED);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class UploadFileTaskTest {
 
         new UploadFileTask(StorjMock.BUCKET, FileMock.FILE_1.getPath()).run();
 
-        //AssertState.assertDB(StorjMock.FILE_1, FileMock.FILE_1, SyncState.SYNCED);
+        AssertState.assertDB(StorjMock.FILE_1, FileMock.FILE_1, SyncState.SYNCED);
     }
 
     @Test

--- a/src/test/java/io/goobox/sync/storj/UploadFileTaskTest.java
+++ b/src/test/java/io/goobox/sync/storj/UploadFileTaskTest.java
@@ -59,7 +59,7 @@ public class UploadFileTaskTest {
 
         new UploadFileTask(StorjMock.BUCKET, FileMock.FILE_1.getPath()).run();
 
-        AssertState.assertDB(StorjMock.FILE_1, FileMock.FILE_1, SyncState.SYNCED);
+        //AssertState.assertDB(StorjMock.FILE_1, FileMock.FILE_1, SyncState.SYNCED);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class UploadFileTaskTest {
 
         new UploadFileTask(StorjMock.BUCKET, FileMock.FILE_1.getPath()).run();
 
-        AssertState.assertDB(StorjMock.FILE_1, FileMock.FILE_1, SyncState.SYNCED);
+        //AssertState.assertDB(StorjMock.FILE_1, FileMock.FILE_1, SyncState.SYNCED);
     }
 
     @Test

--- a/src/test/java/io/goobox/sync/storj/mocks/FilesMock.java
+++ b/src/test/java/io/goobox/sync/storj/mocks/FilesMock.java
@@ -164,7 +164,7 @@ public class FilesMock extends MockUp<Files> {
 
     @Mock
     public Path copy(Path source, Path target, CopyOption... options) throws IOException {
-        return Files.copy(source, target, options);
+        return null;
     }
 
     public void modifyFile(FileMock oldFile, FileMock newFile) {

--- a/src/test/java/io/goobox/sync/storj/mocks/FilesMock.java
+++ b/src/test/java/io/goobox/sync/storj/mocks/FilesMock.java
@@ -17,6 +17,7 @@
 package io.goobox.sync.storj.mocks;
 
 import java.io.IOException;
+import java.nio.file.CopyOption;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitOption;
@@ -159,6 +160,11 @@ public class FilesMock extends MockUp<Files> {
         return Stream.of(files.toArray(new FileMock[files.size()]))
                 .map(FileMock::getPath)
                 .filter(p -> p.startsWith(start));
+    }
+
+    @Mock
+    public Path copy(Path source, Path target, CopyOption... options) throws IOException {
+        return Files.copy(source, target, options);
     }
 
     public void modifyFile(FileMock oldFile, FileMock newFile) {

--- a/src/test/java/io/goobox/sync/storj/mocks/StorjMock.java
+++ b/src/test/java/io/goobox/sync/storj/mocks/StorjMock.java
@@ -160,13 +160,11 @@ public class StorjMock extends MockUp<Storj> {
         } else if (SUB_SUB_FILE.getName().equals(fileName)) {
             files.add(SUB_SUB_FILE);
             callback.onComplete(localPath, SUB_SUB_FILE);
+        } else if (localPath.endsWith(".tmp") && fileName.equals(FILE_1.getName())) {
+            files.add(FILE_1);
+            callback.onComplete(localPath, FILE_1);
         } else {
-            if (localPath.endsWith(".tmp") && !fileName.equals(FILE_2.getName())) {
-                files.add(FILE_1);
-                callback.onComplete(localPath, FILE_1);
-            } else {
-                callback.onError(localPath, Storj.ENOENT, "error uploading");
-            }
+            callback.onError(localPath, Storj.ENOENT, "error uploading");
         }
         return 0;
     }

--- a/src/test/java/io/goobox/sync/storj/mocks/StorjMock.java
+++ b/src/test/java/io/goobox/sync/storj/mocks/StorjMock.java
@@ -161,7 +161,12 @@ public class StorjMock extends MockUp<Storj> {
             files.add(SUB_SUB_FILE);
             callback.onComplete(localPath, SUB_SUB_FILE);
         } else {
-            callback.onError(localPath, Storj.ENOENT, "error uploading");
+            if (localPath.endsWith(".tmp") && !fileName.equals(FILE_2.getName())) {
+                files.add(FILE_1);
+                callback.onComplete(localPath, FILE_1);
+            } else {
+                callback.onError(localPath, Storj.ENOENT, "error uploading");
+            }
         }
         return 0;
     }


### PR DESCRIPTION
This is for issue #63 where at this stage, it is still at prototype, done a few round of tests, looks okay, should tests again to be sure. 

Tested (rename, move, delete) file of size 50MB all fine, both linux and windows. Want to test 100MB but it failed upload from my workstation with the error "Upload failed due to temporary error: Unable to receive storage offer (1014). Trying again"